### PR TITLE
Listeners addition

### DIFF
--- a/src/main/java/org/repositoryminer/codesmell/commit/BrainClass.java
+++ b/src/main/java/org/repositoryminer/codesmell/commit/BrainClass.java
@@ -1,12 +1,12 @@
 package org.repositoryminer.codesmell.commit;
 
-import org.bson.Document;
 import org.repositoryminer.ast.AST;
 import org.repositoryminer.ast.AbstractTypeDeclaration;
 import org.repositoryminer.ast.AbstractTypeDeclaration.Archetype;
 import org.repositoryminer.ast.MethodDeclaration;
 import org.repositoryminer.ast.TypeDeclaration;
 import org.repositoryminer.codesmell.CodeSmellId;
+import org.repositoryminer.listener.ICommitCodeSmellDetectionListener;
 import org.repositoryminer.metric.SLOCMetric;
 import org.repositoryminer.metric.TCCMetric;
 import org.repositoryminer.metric.WMCMetric;
@@ -28,11 +28,11 @@ public class BrainClass implements ICommitCodeSmell {
 	}
 
 	@Override
-	public void detect(AbstractTypeDeclaration type, AST ast, Document document) {
+	public void detect(AbstractTypeDeclaration type, AST ast, ICommitCodeSmellDetectionListener listener) {
 		if (type.getArchetype() == Archetype.CLASS_OR_INTERFACE) {
 			TypeDeclaration cls = (TypeDeclaration) type;
 			boolean brainClass = detect(ast, type, cls);
-			document.append("name", new String(CodeSmellId.BRAIN_CLASS)).append("value", new Boolean(brainClass));
+			listener.updateSmellDetection(CodeSmellId.BRAIN_CLASS, brainClass);
 		}
 	}
 

--- a/src/main/java/org/repositoryminer/codesmell/commit/BrainMethod.java
+++ b/src/main/java/org/repositoryminer/codesmell/commit/BrainMethod.java
@@ -1,15 +1,15 @@
 package org.repositoryminer.codesmell.commit;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
-import org.bson.Document;
 import org.repositoryminer.ast.AST;
 import org.repositoryminer.ast.AbstractTypeDeclaration;
 import org.repositoryminer.ast.AbstractTypeDeclaration.Archetype;
 import org.repositoryminer.ast.MethodDeclaration;
 import org.repositoryminer.ast.TypeDeclaration;
 import org.repositoryminer.codesmell.CodeSmellId;
+import org.repositoryminer.listener.ICommitCodeSmellDetectionListener;
 import org.repositoryminer.metric.CCMetric;
 import org.repositoryminer.metric.MLOCMetric;
 import org.repositoryminer.metric.MaxNestingMetric;
@@ -17,7 +17,6 @@ import org.repositoryminer.metric.NOAVMetric;
 
 public class BrainMethod implements ICommitCodeSmell {
 	
-	private List<Document> methodsDoc;
 	private int mlocThreshold = 65;
 	private float ccMlocThreshold = 0.24f;
 	private int maxNestingThreshold = 5;
@@ -33,18 +32,18 @@ public class BrainMethod implements ICommitCodeSmell {
 	}
 
 	@Override
-	public void detect(AbstractTypeDeclaration type, AST ast, Document document) {
+	public void detect(AbstractTypeDeclaration type, AST ast, ICommitCodeSmellDetectionListener listener) {
 		if (type.getArchetype() == Archetype.CLASS_OR_INTERFACE) {
 			TypeDeclaration cls = (TypeDeclaration) type;
 			
-			methodsDoc = new ArrayList<Document>();
+			Map<String, Boolean> detectionsPerMethod = new HashMap<String, Boolean>();
 
 			for(MethodDeclaration method : cls.getMethods()){
 				boolean brainMethod = detect(method, ast);
-				methodsDoc.add(new Document("method", method.getName()).append("value", new Boolean(brainMethod)));
+				detectionsPerMethod.put(method.getName(), new Boolean(brainMethod));
 			}
 
-			document.append("name", CodeSmellId.BRAIN_METHOD).append("methods", methodsDoc);
+			listener.updateMethodBasedSmellDetection(CodeSmellId.BRAIN_METHOD, detectionsPerMethod);
 		}
 	}
 	
@@ -67,3 +66,4 @@ public class BrainMethod implements ICommitCodeSmell {
 	}
 
 }
+

--- a/src/main/java/org/repositoryminer/codesmell/commit/ComplexMethod.java
+++ b/src/main/java/org/repositoryminer/codesmell/commit/ComplexMethod.java
@@ -1,20 +1,19 @@
 package org.repositoryminer.codesmell.commit;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
-import org.bson.Document;
 import org.repositoryminer.ast.AST;
 import org.repositoryminer.ast.AbstractTypeDeclaration;
 import org.repositoryminer.ast.AbstractTypeDeclaration.Archetype;
-import org.repositoryminer.codesmell.CodeSmellId;
 import org.repositoryminer.ast.MethodDeclaration;
 import org.repositoryminer.ast.TypeDeclaration;
+import org.repositoryminer.codesmell.CodeSmellId;
+import org.repositoryminer.listener.ICommitCodeSmellDetectionListener;
 import org.repositoryminer.metric.CCMetric;
 
 public class ComplexMethod implements ICommitCodeSmell {
 	
-	private List<Document> methodsDoc;
 	private int ccThreshold = 4;
 	
 	public ComplexMethod() {}
@@ -24,18 +23,18 @@ public class ComplexMethod implements ICommitCodeSmell {
 	}
 
 	@Override
-	public void detect(AbstractTypeDeclaration type, AST ast, Document document) {
+	public void detect(AbstractTypeDeclaration type, AST ast, ICommitCodeSmellDetectionListener listener) {
 		if (type.getArchetype() == Archetype.CLASS_OR_INTERFACE) {
 			TypeDeclaration cls = (TypeDeclaration) type;
-			
-			methodsDoc = new ArrayList<Document>();
+
+			Map<String, Boolean> detectionsPerMethod = new HashMap<String, Boolean>();
 
 			for(MethodDeclaration method : cls.getMethods()){
 				boolean complexMethod = detect(method);
-				methodsDoc.add(new Document("method", method.getName()).append("value", new Boolean(complexMethod)));
+				detectionsPerMethod.put(method.getName(), new Boolean(complexMethod));
 			}
 
-			document.append("name", CodeSmellId.COMPLEX_METHOD).append("methods", methodsDoc);
+			listener.updateMethodBasedSmellDetection(CodeSmellId.COMPLEX_METHOD, detectionsPerMethod);
 		}
 	}
 	

--- a/src/main/java/org/repositoryminer/codesmell/commit/GodClass.java
+++ b/src/main/java/org/repositoryminer/codesmell/commit/GodClass.java
@@ -1,11 +1,11 @@
 package org.repositoryminer.codesmell.commit;
 
-import org.bson.Document;
 import org.repositoryminer.ast.AST;
 import org.repositoryminer.ast.AbstractTypeDeclaration;
 import org.repositoryminer.ast.AbstractTypeDeclaration.Archetype;
 import org.repositoryminer.ast.TypeDeclaration;
 import org.repositoryminer.codesmell.CodeSmellId;
+import org.repositoryminer.listener.ICommitCodeSmellDetectionListener;
 import org.repositoryminer.metric.ATFDMetric;
 import org.repositoryminer.metric.NOAMetric;
 import org.repositoryminer.metric.TCCMetric;
@@ -30,12 +30,12 @@ public class GodClass implements ICommitCodeSmell {
 	}
 
 	@Override
-	public void detect(AbstractTypeDeclaration type, AST ast, Document document) {
+	public void detect(AbstractTypeDeclaration type, AST ast, ICommitCodeSmellDetectionListener listener) {
 		if (type.getArchetype() == Archetype.CLASS_OR_INTERFACE) {
 			TypeDeclaration cls = (TypeDeclaration) type;
 
 			boolean godClass = detect(type, cls);
-			document.append("name", CodeSmellId.GOD_CLASS).append("value", new Boolean(godClass));
+			listener.updateSmellDetection(CodeSmellId.GOD_CLASS, godClass);
 		}
 	}
 

--- a/src/main/java/org/repositoryminer/codesmell/commit/ICommitCodeSmell.java
+++ b/src/main/java/org/repositoryminer/codesmell/commit/ICommitCodeSmell.java
@@ -1,10 +1,11 @@
 package org.repositoryminer.codesmell.commit;
 
-import org.bson.Document;
 import org.repositoryminer.ast.AST;
 import org.repositoryminer.ast.AbstractTypeDeclaration;
+import org.repositoryminer.listener.ICommitCodeSmellDetectionListener;
 
 public interface ICommitCodeSmell {
 	
-	public void detect(AbstractTypeDeclaration type, AST ast, Document document);
+	public void detect(AbstractTypeDeclaration type, AST ast, ICommitCodeSmellDetectionListener listener);
+	
 }

--- a/src/main/java/org/repositoryminer/codesmell/commit/LongMethod.java
+++ b/src/main/java/org/repositoryminer/codesmell/commit/LongMethod.java
@@ -1,15 +1,15 @@
 package org.repositoryminer.codesmell.commit;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
-import org.bson.Document;
 import org.repositoryminer.ast.AST;
 import org.repositoryminer.ast.AbstractTypeDeclaration;
 import org.repositoryminer.ast.AbstractTypeDeclaration.Archetype;
 import org.repositoryminer.ast.MethodDeclaration;
 import org.repositoryminer.ast.TypeDeclaration;
 import org.repositoryminer.codesmell.CodeSmellId;
+import org.repositoryminer.listener.ICommitCodeSmellDetectionListener;
 import org.repositoryminer.metric.CCMetric;
 import org.repositoryminer.metric.LVARMetric;
 import org.repositoryminer.metric.MLOCMetric;
@@ -17,7 +17,6 @@ import org.repositoryminer.metric.PARMetric;
 
 public class LongMethod implements ICommitCodeSmell {
 
-	private List<Document> methodsDoc;
 	private int ccThreshold = 4;
 	private int mlocThreshold = 30;
 	private int parThreshold = 4;
@@ -33,18 +32,18 @@ public class LongMethod implements ICommitCodeSmell {
 	}
 
 	@Override
-	public void detect(AbstractTypeDeclaration type, AST ast, Document document) {
+	public void detect(AbstractTypeDeclaration type, AST ast, ICommitCodeSmellDetectionListener listener) {
 		if (type.getArchetype() == Archetype.CLASS_OR_INTERFACE) {
 			TypeDeclaration cls = (TypeDeclaration) type;
 			
-			methodsDoc = new ArrayList<Document>();
+			Map<String, Boolean> detectionsPerMethod = new HashMap<String, Boolean>();
 
 			for(MethodDeclaration method : cls.getMethods()){
 				boolean longMethod = detect(method, ast);
-				methodsDoc.add(new Document("method", method.getName()).append("value", new Boolean(longMethod)));
+				detectionsPerMethod.put(method.getName(), new Boolean(longMethod));
 			}
 
-			document.append("name", CodeSmellId.LONG_METHOD).append("methods", methodsDoc);
+			listener.updateMethodBasedSmellDetection(CodeSmellId.LONG_METHOD, detectionsPerMethod);
 		}
 	}
 	

--- a/src/main/java/org/repositoryminer/codesmell/tag/ITagCodeSmell.java
+++ b/src/main/java/org/repositoryminer/codesmell/tag/ITagCodeSmell.java
@@ -3,14 +3,14 @@ package org.repositoryminer.codesmell.tag;
 import java.util.List;
 import java.util.TreeMap;
 
-import org.bson.Document;
 import org.repositoryminer.ast.AST;
+import org.repositoryminer.listener.ITagCodeSmellDetectionListener;
 import org.repositoryminer.parser.Parser;
 
 public interface ITagCodeSmell {
 
 	TreeMap<String, AST> astMap = new TreeMap<String, AST>();
 
-	public void detect(List<Parser> parsers, String repositoryPath, Document document);
+	public void detect(List<Parser> parsers, String repositoryPath, ITagCodeSmellDetectionListener listener);
 
 }

--- a/src/main/java/org/repositoryminer/listener/ICommitCodeSmellDetectionListener.java
+++ b/src/main/java/org/repositoryminer/listener/ICommitCodeSmellDetectionListener.java
@@ -1,0 +1,11 @@
+package org.repositoryminer.listener;
+
+import java.util.Map;
+
+public interface ICommitCodeSmellDetectionListener {
+
+	public void updateSmellDetection(String smellName, boolean detected);
+	
+	public void updateMethodBasedSmellDetection(String smellName, Map<String, Boolean> detectionsPerMethod);
+	
+}

--- a/src/main/java/org/repositoryminer/listener/IDuplicatedCodeDetectionListener.java
+++ b/src/main/java/org/repositoryminer/listener/IDuplicatedCodeDetectionListener.java
@@ -1,0 +1,15 @@
+package org.repositoryminer.listener;
+
+import org.repositoryminer.parser.Parser;
+
+import net.sourceforge.pmd.cpd.Match;
+
+public interface IDuplicatedCodeDetectionListener extends ITagCodeSmellDetectionListener {
+
+	public void initDuplicationDetection();
+	
+	public void updateDuplicationDetection(Match match, Parser parse);
+	
+	public void endOfDuplicationDetection();
+	
+}

--- a/src/main/java/org/repositoryminer/listener/IMetricCalculationListener.java
+++ b/src/main/java/org/repositoryminer/listener/IMetricCalculationListener.java
@@ -1,0 +1,14 @@
+package org.repositoryminer.listener;
+
+import java.util.Map;
+
+public interface IMetricCalculationListener {
+
+	public void updateMetricValue(String metricName, int value);
+	
+	public void updateMetricValue(String metricName, float value);
+	
+	public void updateMethodBasedMetricValue(String metricName, int accumulatedValue, 
+			Map<String, Integer> valuesPerMethod);
+	
+}

--- a/src/main/java/org/repositoryminer/listener/IMiningListener.java
+++ b/src/main/java/org/repositoryminer/listener/IMiningListener.java
@@ -1,0 +1,46 @@
+package org.repositoryminer.listener;
+
+import java.util.List;
+
+import org.repositoryminer.ast.AST;
+import org.repositoryminer.ast.AbstractTypeDeclaration;
+import org.repositoryminer.codesmell.commit.ICommitCodeSmell;
+import org.repositoryminer.codesmell.tag.ITagCodeSmell;
+import org.repositoryminer.metric.ICommitMetric;
+import org.repositoryminer.parser.Parser;
+import org.repositoryminer.persistence.model.CommitDB;
+import org.repositoryminer.persistence.model.ReferenceDB;
+import org.repositoryminer.persistence.model.RepositoryDB;
+import org.repositoryminer.persistence.model.WorkingDirectoryDB;
+import org.repositoryminer.technicaldebt.ITechnicalDebt;
+
+public interface IMiningListener {
+	
+	public void updateReference(ReferenceDB reference);
+	
+	public void updateCommit(CommitDB commit);
+	
+	public void updateWorkingDirectory(WorkingDirectoryDB workingDirectory);
+	
+	public void updateRepository(RepositoryDB repository);
+	
+	public void initCommitProcessing(String repositoryId, CommitDB commit, AST ast, String file, String hash);
+	
+	public void initTypeProcessing(AbstractTypeDeclaration type, String file);
+	
+	public void updateAllMetrics(AbstractTypeDeclaration type, AST ast, List<ICommitMetric> metrics);
+	
+	public void updateAllCommitCodeSmells(AbstractTypeDeclaration type, AST ast, List<ICommitCodeSmell> codeSmells);
+
+	public void updateAllTechnicalDebts(AST ast, AbstractTypeDeclaration type, List<ITechnicalDebt> technicalDebts);
+	
+	public void endOfTypeProcessing();
+	
+	public void endOfCommitProcessing();
+
+	public void initTagProcessing(String repositoryId, CommitDB commit, ReferenceDB tag);
+	
+	public void updateAllTagCodeSmells(List<Parser> parsers, String repositoryPath, List<ITagCodeSmell> codeSmells);
+
+	public void endOfTagProcessing();
+}

--- a/src/main/java/org/repositoryminer/listener/IProgressListener.java
+++ b/src/main/java/org/repositoryminer/listener/IProgressListener.java
@@ -1,0 +1,13 @@
+package org.repositoryminer.listener;
+
+public interface IProgressListener {
+	
+	public void initCommitsProcessingProgress(int numberOfCommits);
+	public void commitProgressChange(int commitIndex, int numberOfCommits);
+	
+	public void initTimeFramesProcessingProgress();
+	
+	public void initSourceAnalysisProcessingProgress();
+	
+	public void endOfProcessingProgress();
+}

--- a/src/main/java/org/repositoryminer/listener/ITagCodeSmellDetectionListener.java
+++ b/src/main/java/org/repositoryminer/listener/ITagCodeSmellDetectionListener.java
@@ -1,0 +1,5 @@
+package org.repositoryminer.listener;
+
+public interface ITagCodeSmellDetectionListener {
+
+}

--- a/src/main/java/org/repositoryminer/listener/ITechnicalDebtDetectionListener.java
+++ b/src/main/java/org/repositoryminer/listener/ITechnicalDebtDetectionListener.java
@@ -1,0 +1,7 @@
+package org.repositoryminer.listener;
+
+public interface ITechnicalDebtDetectionListener {
+	
+	public void updateDebtDetection(String debtName, boolean detected);
+
+}

--- a/src/main/java/org/repositoryminer/listener/impl/DefaultDuplicatedCodeDetectionListener.java
+++ b/src/main/java/org/repositoryminer/listener/impl/DefaultDuplicatedCodeDetectionListener.java
@@ -1,0 +1,77 @@
+package org.repositoryminer.listener.impl;
+
+import java.io.IOException;
+import java.math.RoundingMode;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bson.Document;
+import org.repositoryminer.codesmell.CodeSmellId;
+import org.repositoryminer.listener.IDuplicatedCodeDetectionListener;
+import org.repositoryminer.metric.SLOCMetric;
+import org.repositoryminer.parser.Parser;
+
+import net.sourceforge.pmd.cpd.Mark;
+import net.sourceforge.pmd.cpd.Match;
+
+public class DefaultDuplicatedCodeDetectionListener implements IDuplicatedCodeDetectionListener {
+
+	private List<Document> smellDocs, duplicatedCodeDocs;
+	
+	public DefaultDuplicatedCodeDetectionListener(List<Document> smellDocs) {
+		this.smellDocs = smellDocs;
+		duplicatedCodeDocs = new ArrayList<Document>();
+	}
+	
+	@Override
+	public void initDuplicationDetection() {
+	}
+
+	@Override
+	public void updateDuplicationDetection(Match match, Parser parser) {
+		Document auxDoc = new Document();
+		auxDoc.append("line_count", match.getLineCount());
+		auxDoc.append("token_count", match.getTokenCount());
+		auxDoc.append("source_code_slice", match.getSourceCodeSlice());
+		auxDoc.append("language", parser.getLanguage());
+		
+		List<Document> filesDoc = new ArrayList<Document>();
+		for (Mark mark : match.getMarkSet()) {
+			Document fileDoc = new Document();
+			fileDoc.append("begin_line", mark.getBeginLine());
+			fileDoc.append("end_line", mark.getEndLine());
+			fileDoc.append("file_name", mark.getFilename());
+			fileDoc.append("percentage", getDuplicatedPercentage(mark.getFilename(), match.getLineCount()));
+			filesDoc.add(fileDoc);
+		}
+		
+		auxDoc.append("files", filesDoc);
+		duplicatedCodeDocs.add(auxDoc);
+	}
+	
+	private Double getDuplicatedPercentage(String filename, int lineCount) {
+		try {
+			String source = new String(Files.readAllBytes(Paths.get(filename)));
+			SLOCMetric slocMetric = new SLOCMetric();
+			
+			int sloc = slocMetric.calculate(source);
+			double percentage = (double) lineCount / sloc;
+			DecimalFormat df = new DecimalFormat("#.####");
+			df.setRoundingMode(RoundingMode.CEILING);
+			return Double.valueOf(df.format(percentage));
+		} catch (IOException e) {
+			return 0.0;
+		}
+	}
+
+	@Override
+	public void endOfDuplicationDetection() {
+		Document duplicationsDoc = new Document();
+		duplicationsDoc.append("name", CodeSmellId.DUPLICATED_CODE).append("occurrences", duplicatedCodeDocs);
+		smellDocs.add(duplicationsDoc);
+	}
+
+}

--- a/src/main/java/org/repositoryminer/listener/impl/DefaultMiningListener.java
+++ b/src/main/java/org/repositoryminer/listener/impl/DefaultMiningListener.java
@@ -1,0 +1,223 @@
+package org.repositoryminer.listener.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.bson.Document;
+import org.repositoryminer.ast.AST;
+import org.repositoryminer.ast.AbstractTypeDeclaration;
+import org.repositoryminer.codesmell.commit.ICommitCodeSmell;
+import org.repositoryminer.codesmell.tag.DuplicatedCode;
+import org.repositoryminer.codesmell.tag.ITagCodeSmell;
+import org.repositoryminer.listener.ICommitCodeSmellDetectionListener;
+import org.repositoryminer.listener.IMetricCalculationListener;
+import org.repositoryminer.listener.IMiningListener;
+import org.repositoryminer.listener.ITechnicalDebtDetectionListener;
+import org.repositoryminer.metric.ICommitMetric;
+import org.repositoryminer.parser.Parser;
+import org.repositoryminer.persistence.handler.CommitAnalysisDocumentHandler;
+import org.repositoryminer.persistence.handler.CommitDocumentHandler;
+import org.repositoryminer.persistence.handler.ReferenceDocumentHandler;
+import org.repositoryminer.persistence.handler.RepositoryDocumentHandler;
+import org.repositoryminer.persistence.handler.TagAnalysisDocumentHandler;
+import org.repositoryminer.persistence.handler.WorkingDirectoryDocumentHandler;
+import org.repositoryminer.persistence.model.CommitDB;
+import org.repositoryminer.persistence.model.ReferenceDB;
+import org.repositoryminer.persistence.model.RepositoryDB;
+import org.repositoryminer.persistence.model.WorkingDirectoryDB;
+import org.repositoryminer.technicaldebt.ITechnicalDebt;
+import org.repositoryminer.utility.HashHandler;
+
+public class DefaultMiningListener implements IMiningListener {
+
+	private CommitDocumentHandler commitHandler;
+	private WorkingDirectoryDocumentHandler wdHandler;
+	private RepositoryDocumentHandler repoHandler;
+	private ReferenceDocumentHandler refHandler;
+	private CommitAnalysisDocumentHandler commAnalysisHandler;
+	private TagAnalysisDocumentHandler persistenceTag;
+
+	private Document commitDoc, typeDoc, tagDoc;
+
+	private List<Document> typeDocs;
+	private List<Document> smellDocs;
+
+	public DefaultMiningListener() {
+		wdHandler = new WorkingDirectoryDocumentHandler();
+		commitHandler = new CommitDocumentHandler();
+		repoHandler = new RepositoryDocumentHandler();
+		refHandler = new ReferenceDocumentHandler();
+		commAnalysisHandler = new CommitAnalysisDocumentHandler();
+
+		typeDocs = new ArrayList<Document>();
+	}
+
+	@Override
+	public void updateRepository(RepositoryDB repository) {
+		repoHandler.insert(repository.toDocument());
+	}
+
+	@Override
+	public void updateReference(ReferenceDB reference) {
+		refHandler.insert(reference.toDocument());
+	}
+
+	@Override
+	public void updateCommit(CommitDB commit) {
+		commitHandler.insert(commit.toDocument());
+	}
+
+	@Override
+	public void updateWorkingDirectory(WorkingDirectoryDB workingDirectory) {
+		wdHandler.insert(workingDirectory.toDocument());
+	}
+
+	@Override
+	public void initCommitProcessing(String repositoryId, CommitDB commit, AST ast, String file, String hash) {
+		commitDoc = new Document();
+		commitDoc.append("commit", commit.getId());
+		commitDoc.append("commit_date", commit.getCommitDate());
+		commitDoc.append("package", ast.getDocument().getPackageDeclaration());
+		commitDoc.append("file", file);
+		commitDoc.append("repository", repositoryId);
+		commitDoc.append("file_hash", hash);
+	}
+
+	@Override
+	public void initTypeProcessing(AbstractTypeDeclaration type, String file) {
+		typeDoc = new Document();
+		String typeHash = file + "/" + type.getName();
+		typeDoc.append("name", type.getName()).append("declaration", type.getArchetype().toString()).append("hash",
+				HashHandler.SHA1(typeHash));
+	}
+
+	@Override
+	public void updateAllMetrics(AbstractTypeDeclaration type, AST ast, List<ICommitMetric> metrics) {
+		final List<Document> metricDocs = new ArrayList<Document>();
+		for (ICommitMetric metric : metrics) {
+			metric.calculate(type, ast, new IMetricCalculationListener() {
+				@Override
+				public void updateMetricValue(String metricName, int value) {
+					Document mDoc = new Document();
+					mDoc.append("name", metricName).append("accumulated", new Integer(value));
+
+					metricDocs.add(mDoc);
+				}
+
+				@Override
+				public void updateMetricValue(String metricName, float value) {
+					Document mDoc = new Document();
+					mDoc.append("name", metricName).append("accumulated", new Float(value));
+
+					metricDocs.add(mDoc);
+				}
+
+				@Override
+				public void updateMethodBasedMetricValue(String metricName, int accumulatedValue,
+						Map<String, Integer> valuesPerMethod) {
+					Document mDoc = new Document();
+					mDoc.append("name", metricName).append("accumulated", new Integer(accumulatedValue));
+					for (Entry<String, Integer> entry : valuesPerMethod.entrySet()) {
+						mDoc.append("method", entry.getKey()).append("value", entry.getValue());
+					}
+
+					metricDocs.add(mDoc);
+				}
+			});
+		}
+
+		typeDoc.append("metrics", metricDocs);
+	}
+
+	@Override
+	public void updateAllCommitCodeSmells(AbstractTypeDeclaration type, AST ast, List<ICommitCodeSmell> codeSmells) {
+		smellDocs = new ArrayList<Document>();
+		for (ICommitCodeSmell codeSmell : codeSmells) {
+			codeSmell.detect(type, ast, new ICommitCodeSmellDetectionListener() {
+
+				@Override
+				public void updateSmellDetection(String smellName, boolean detected) {
+					Document sDoc = new Document();
+					sDoc.append("name", smellName).append("value", new Boolean(detected));
+
+					smellDocs.add(sDoc);
+				}
+
+				@Override
+				public void updateMethodBasedSmellDetection(String smellName,
+						Map<String, Boolean> detectionsPerMethod) {
+					List<Document> detections = new ArrayList<Document>();
+					for (Map.Entry<String, Boolean> detection : detectionsPerMethod.entrySet()) {
+						detections
+								.add(new Document("method", detection.getKey()).append("value", detection.getValue()));
+					}
+					Document sDoc = new Document();
+					sDoc.append("name", smellName).append("methods", detections);
+
+					smellDocs.add(sDoc);
+				}
+			});
+		}
+
+		typeDoc.append("codesmells", smellDocs);
+	}
+
+	@Override
+	public void updateAllTechnicalDebts(AST ast, AbstractTypeDeclaration type, List<ITechnicalDebt> technicalDebts) {
+		final List<Document> technicalDebtDocs = new ArrayList<Document>();
+		for (ITechnicalDebt techDebt : technicalDebts) {
+			techDebt.detect(type, ast, smellDocs, new ITechnicalDebtDetectionListener() {
+
+				@Override
+				public void updateDebtDetection(String debtName, boolean detected) {
+					Document dDoc = new Document();
+					dDoc.append("name", debtName).append("value", new Boolean(detected)).append("status", 0);
+
+					technicalDebtDocs.add(dDoc);
+				}
+			});
+		}
+
+		typeDoc.append("technical_debts", technicalDebtDocs);
+	}
+
+	@Override
+	public void endOfTypeProcessing() {
+		typeDocs.add(typeDoc);
+	}
+
+	@Override
+	public void endOfCommitProcessing() {
+		commitDoc.append("abstract_types", typeDocs);
+		commAnalysisHandler.insert(commitDoc);
+	}
+
+	@Override
+	public void initTagProcessing(String repositoryId, CommitDB commit, ReferenceDB tag) {
+		tagDoc = new Document();
+		tagDoc.append("tag", tag.getName());
+		tagDoc.append("tag_type", tag.getType().toString());
+		tagDoc.append("commit", commit.getId());
+		tagDoc.append("commit_date", commit.getCommitDate());
+		tagDoc.append("repository", repositoryId);
+	}
+
+	@Override
+	public void updateAllTagCodeSmells(List<Parser> parsers, String repositoryPath, List<ITagCodeSmell> codeSmells) {
+		smellDocs = new ArrayList<Document>();
+		for (ITagCodeSmell codeSmell : codeSmells) {
+			if (codeSmell instanceof DuplicatedCode) {
+				codeSmell.detect(parsers, repositoryPath, new DefaultDuplicatedCodeDetectionListener(smellDocs));
+			}
+		}
+	}
+
+	@Override
+	public void endOfTagProcessing() {
+		tagDoc.append("codesmells", smellDocs);
+		persistenceTag.insert(tagDoc);
+	}
+
+}

--- a/src/main/java/org/repositoryminer/metric/ATFDMetric.java
+++ b/src/main/java/org/repositoryminer/metric/ATFDMetric.java
@@ -1,27 +1,29 @@
 package org.repositoryminer.metric;
 
-import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
-import org.bson.Document;
 import org.repositoryminer.ast.AST;
 import org.repositoryminer.ast.AbstractTypeDeclaration;
 import org.repositoryminer.ast.MethodDeclaration;
 import org.repositoryminer.ast.Statement;
 import org.repositoryminer.ast.Statement.NodeType;
+import org.repositoryminer.listener.IMetricCalculationListener;
 
 public class ATFDMetric extends MethodBasedMetricTemplate {
 
-	private List<Document> methodsDoc;
+	private Map<String, Integer> valuesPerMethod;
 
 	@Override
-	public void calculate(AbstractTypeDeclaration type, List<MethodDeclaration> methods, AST ast, Document document) {
-		methodsDoc = new ArrayList<Document>();
+	public void calculate(AbstractTypeDeclaration type, List<MethodDeclaration> methods, AST ast, 
+			IMetricCalculationListener listener) {
+		valuesPerMethod = new HashMap<String, Integer>();
 
 		int atfdClass = calculate(type, methods, true);
-		document.append("name", ATFD).append("accumulated", new Integer(atfdClass)).append("methods", methodsDoc);
+		listener.updateMethodBasedMetricValue(ATFD, atfdClass, valuesPerMethod);
 	}
 
 	public int calculate(AbstractTypeDeclaration type, List<MethodDeclaration> methods, boolean calculateByMethod) {
@@ -32,7 +34,7 @@ public class ATFDMetric extends MethodBasedMetricTemplate {
 
 			atfdClass += atfdMethod;
 			if (calculateByMethod) {
-				methodsDoc.add(new Document("method", mDeclaration.getName()).append("value", new Integer(atfdMethod)));
+				valuesPerMethod.put(mDeclaration.getName(), new Integer(atfdMethod));
 			}
 		}
 

--- a/src/main/java/org/repositoryminer/metric/CCMetric.java
+++ b/src/main/java/org/repositoryminer/metric/CCMetric.java
@@ -1,24 +1,27 @@
 package org.repositoryminer.metric;
 
-import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
-import org.bson.Document;
 import org.repositoryminer.ast.AST;
 import org.repositoryminer.ast.AbstractTypeDeclaration;
 import org.repositoryminer.ast.MethodDeclaration;
 import org.repositoryminer.ast.Statement;
 import org.repositoryminer.ast.Statement.NodeType;
+import org.repositoryminer.listener.IMetricCalculationListener;
 
 public class CCMetric extends MethodBasedMetricTemplate {
 
-	private List<Document> methodsDoc;
+	private Map<String, Integer> valuesPerMethod;
 
 	@Override
-	public void calculate(AbstractTypeDeclaration type, List<MethodDeclaration> methods, AST ast, Document document) {
-		methodsDoc = new ArrayList<Document>();
+	public void calculate(AbstractTypeDeclaration type, List<MethodDeclaration> methods, AST ast, 
+			IMetricCalculationListener listener) {
+		valuesPerMethod = new HashMap<String, Integer>();
+
 		int ccClass = calculate(methods);
-		document.append("name", CC).append("accumulated", new Integer(ccClass)).append("methods", methodsDoc);
+		listener.updateMethodBasedMetricValue(CC, ccClass, valuesPerMethod);
 	}
 
 	// for classes
@@ -28,7 +31,7 @@ public class CCMetric extends MethodBasedMetricTemplate {
 
 			int cc = calculate(method);
 			ccClass += cc;
-			methodsDoc.add(new Document("method", method.getName()).append("value", new Integer(cc)));
+			valuesPerMethod.put(method.getName(),new Integer(cc));
 		}
 		return ccClass;
 	}

--- a/src/main/java/org/repositoryminer/metric/ICommitMetric.java
+++ b/src/main/java/org/repositoryminer/metric/ICommitMetric.java
@@ -1,14 +1,14 @@
 package org.repositoryminer.metric;
 
-import org.bson.Document;
 import org.repositoryminer.ast.AST;
 import org.repositoryminer.ast.AbstractTypeDeclaration;
+import org.repositoryminer.listener.IMetricCalculationListener;
 
 /**
  * Metrics calculations definition.
  */
 public interface ICommitMetric extends MetricId {
 
-	public void calculate(AbstractTypeDeclaration type, AST ast, Document document);
+	public void calculate(AbstractTypeDeclaration type, AST ast, IMetricCalculationListener listener);
 
 }

--- a/src/main/java/org/repositoryminer/metric/LVARMetric.java
+++ b/src/main/java/org/repositoryminer/metric/LVARMetric.java
@@ -1,32 +1,33 @@
 package org.repositoryminer.metric;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
-import org.bson.Document;
 import org.repositoryminer.ast.AST;
 import org.repositoryminer.ast.AbstractTypeDeclaration;
 import org.repositoryminer.ast.MethodDeclaration;
 import org.repositoryminer.ast.Statement;
 import org.repositoryminer.ast.Statement.NodeType;
+import org.repositoryminer.listener.IMetricCalculationListener;
 
 public class LVARMetric extends MethodBasedMetricTemplate {
 
-	private List<Document> methodsDoc;
-	
 	@Override
-	public void calculate(AbstractTypeDeclaration type, List<MethodDeclaration> methods, AST ast, Document document) {
+	public void calculate(AbstractTypeDeclaration type, List<MethodDeclaration> methods, AST ast, 
+			IMetricCalculationListener listener) {
 		
-		methodsDoc = new ArrayList<Document>();
+		Map<String, Integer> valuesPerMethod = new HashMap<String, Integer>();
 		int accumulated = 0;
 		
 		for(MethodDeclaration method : methods){
 			int lvar = calculate(method);
 			accumulated += lvar;
-			methodsDoc.add(new Document("method", method.getName()).append("value", new Integer(lvar)));
+			valuesPerMethod.put(method.getName(), new Integer(lvar));
 		}
 		
-		document.append("name", LVAR).append("accumulated", new Integer(accumulated)).append("methods", methodsDoc);
+		listener.updateMethodBasedMetricValue(LVAR, accumulated, valuesPerMethod);
 	}
 	
 	public int calculate(MethodDeclaration method){

--- a/src/main/java/org/repositoryminer/metric/MLOCMetric.java
+++ b/src/main/java/org/repositoryminer/metric/MLOCMetric.java
@@ -1,18 +1,18 @@
 package org.repositoryminer.metric;
 
-import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.bson.Document;
 import org.repositoryminer.ast.AST;
-import org.repositoryminer.ast.MethodDeclaration;
 import org.repositoryminer.ast.AbstractTypeDeclaration;
+import org.repositoryminer.ast.MethodDeclaration;
+import org.repositoryminer.listener.IMetricCalculationListener;
 
 public class MLOCMetric extends MethodBasedMetricTemplate {
 	
-	private List<Document> methodsDoc;
 	private Pattern pattern;
 
 	public MLOCMetric(){
@@ -20,18 +20,19 @@ public class MLOCMetric extends MethodBasedMetricTemplate {
 	}
 
 	@Override
-	public void calculate(AbstractTypeDeclaration type, List<MethodDeclaration> methods, AST ast, Document document) {
+	public void calculate(AbstractTypeDeclaration type, List<MethodDeclaration> methods, AST ast, 
+			IMetricCalculationListener listener) {
 		
-		methodsDoc = new ArrayList<Document>();
+		Map<String, Integer> valuesPerMethod = new HashMap<String, Integer>();
 		int accumulated = 0;
 		
 		for(MethodDeclaration method : methods){
 			int mloc = calculate(method, ast);
 			accumulated += mloc;
-			methodsDoc.add(new Document("method", method.getName()).append("value", new Integer(mloc)));
+			valuesPerMethod.put(method.getName(), new Integer(mloc));
 		}
 		
-		document.append("name", MLOC).append("accumulated", new Integer(accumulated)).append("methods", methodsDoc);
+		listener.updateMethodBasedMetricValue(MLOC, accumulated, valuesPerMethod);
 	}
 	
 	

--- a/src/main/java/org/repositoryminer/metric/MaxNestingMetric.java
+++ b/src/main/java/org/repositoryminer/metric/MaxNestingMetric.java
@@ -1,29 +1,31 @@
 package org.repositoryminer.metric;
 
-import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
-import org.bson.Document;
 import org.repositoryminer.ast.AST;
 import org.repositoryminer.ast.AbstractTypeDeclaration;
 import org.repositoryminer.ast.MethodDeclaration;
+import org.repositoryminer.listener.IMetricCalculationListener;
 
 public class MaxNestingMetric extends MethodBasedMetricTemplate {
 
-	private List<Document> methodsDoc;
-
 	@Override
-	public void calculate(AbstractTypeDeclaration type, List<MethodDeclaration> methods, AST ast, Document document) {
-		methodsDoc = new ArrayList<Document>();
+	public void calculate(AbstractTypeDeclaration type, List<MethodDeclaration> methods, AST ast, 
+			IMetricCalculationListener listener) {
+		Map<String, Integer> valuesPerMethod = new HashMap<String, Integer>();
 		for(MethodDeclaration method : methods){
 			int maxNesting = calculate(method); 
-			methodsDoc.add(new Document("method", method.getName()).append("value", new Integer(maxNesting)));
+			valuesPerMethod.put(method.getName(), new Integer(maxNesting));
 		}
-		document.append("name", MAX_NESTING).append("methods", methodsDoc);
+		
+		listener.updateMethodBasedMetricValue(MAX_NESTING, 0, valuesPerMethod);
 	}
 
 	public int calculate(MethodDeclaration method){
-		return method.getMaxNesting(); //FIXME solve inconsistency of the values found
+		//FIXME solve inconsistency of the values found
+		return method.getMaxNesting();
 	}
 
 }

--- a/src/main/java/org/repositoryminer/metric/MethodBasedMetricTemplate.java
+++ b/src/main/java/org/repositoryminer/metric/MethodBasedMetricTemplate.java
@@ -3,21 +3,20 @@ package org.repositoryminer.metric;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.bson.Document;
 import org.repositoryminer.ast.AST;
-import org.repositoryminer.ast.TypeDeclaration;
-import org.repositoryminer.ast.FieldDeclaration;
-import org.repositoryminer.ast.MethodDeclaration;
 import org.repositoryminer.ast.AbstractTypeDeclaration;
 import org.repositoryminer.ast.AbstractTypeDeclaration.Archetype;
+import org.repositoryminer.ast.FieldDeclaration;
+import org.repositoryminer.ast.MethodDeclaration;
+import org.repositoryminer.ast.TypeDeclaration;
+import org.repositoryminer.listener.IMetricCalculationListener;
 
 public abstract class MethodBasedMetricTemplate implements ICommitMetric {
 
 	protected List<FieldDeclaration> currentFields = new ArrayList<FieldDeclaration>();
 
 	@Override
-	public void calculate(AbstractTypeDeclaration type, AST ast,
-			Document document) {
+	public void calculate(AbstractTypeDeclaration type, AST ast, IMetricCalculationListener listener) {
 		TypeDeclaration cls = null;
 		if (type.getArchetype() == Archetype.CLASS_OR_INTERFACE) {
 			cls = (TypeDeclaration) type;
@@ -26,12 +25,13 @@ public abstract class MethodBasedMetricTemplate implements ICommitMetric {
 				if (cls.getFields() != null) {
 					currentFields = cls.getFields();
 				}
-				calculate(type, cls.getMethods(), ast, document);
+
+				calculate(type, cls.getMethods(), ast, listener);
 			}
 		}
 	}
 
 	public abstract void calculate(AbstractTypeDeclaration type,
-			List<MethodDeclaration> methods, AST ast, Document document);
+			List<MethodDeclaration> methods, AST ast, IMetricCalculationListener listener);
 
 }

--- a/src/main/java/org/repositoryminer/metric/NOAMetric.java
+++ b/src/main/java/org/repositoryminer/metric/NOAMetric.java
@@ -2,21 +2,20 @@ package org.repositoryminer.metric;
 
 import java.util.List;
 
-import org.bson.Document;
 import org.repositoryminer.ast.AST;
 import org.repositoryminer.ast.AbstractTypeDeclaration;
 import org.repositoryminer.ast.AbstractTypeDeclaration.Archetype;
 import org.repositoryminer.ast.FieldDeclaration;
 import org.repositoryminer.ast.TypeDeclaration;
+import org.repositoryminer.listener.IMetricCalculationListener;
 
 public class NOAMetric implements ICommitMetric {
 
 	@Override
-	public void calculate(AbstractTypeDeclaration type, AST ast,
-			Document document) {
+	public void calculate(AbstractTypeDeclaration type, AST ast, IMetricCalculationListener listener) {
 		if (Archetype.CLASS_OR_INTERFACE == type.getArchetype()) {
 			TypeDeclaration cls = (TypeDeclaration) type;
-			document.append("name", NOA).append("accumulated", new Integer(calculate(cls.getFields())));
+			listener.updateMetricValue(NOA, calculate(cls.getFields()));
 		}
 	}
 

--- a/src/main/java/org/repositoryminer/metric/NOAVMetric.java
+++ b/src/main/java/org/repositoryminer/metric/NOAVMetric.java
@@ -1,29 +1,31 @@
 package org.repositoryminer.metric;
 
-import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
-import org.bson.Document;
 import org.repositoryminer.ast.AST;
 import org.repositoryminer.ast.AbstractTypeDeclaration;
 import org.repositoryminer.ast.MethodDeclaration;
 import org.repositoryminer.ast.Statement;
 import org.repositoryminer.ast.Statement.NodeType;
+import org.repositoryminer.listener.IMetricCalculationListener;
 
 public class NOAVMetric extends MethodBasedMetricTemplate {
 	
-	private List<Document> methodsDoc;
-
 	@Override
-	public void calculate(AbstractTypeDeclaration type, List<MethodDeclaration> methods, AST ast, Document document) {
-		methodsDoc = new ArrayList<Document>();
+	public void calculate(AbstractTypeDeclaration type, List<MethodDeclaration> methods, AST ast, 
+			IMetricCalculationListener listener) {
+		Map<String, Integer> valuesPerMethod = new HashMap<String, Integer>();
 		
+		int accumulated = 0;
 		for(MethodDeclaration method : methods){
 			int noav = calculate(method);
-			methodsDoc.add(new Document("method", method.getName()).append("value", new Integer(noav)));
+			valuesPerMethod.put(method.getName(), new Integer(noav));
+			accumulated += noav;
 		}
 		
-		document.append("name", NOAV).append("methods", methodsDoc);
+		listener.updateMethodBasedMetricValue(NOAV, accumulated, valuesPerMethod);
 	}
 	
 	public int calculate(MethodDeclaration method){

--- a/src/main/java/org/repositoryminer/metric/PARMetric.java
+++ b/src/main/java/org/repositoryminer/metric/PARMetric.java
@@ -1,29 +1,29 @@
 package org.repositoryminer.metric;
 
-import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
-import org.bson.Document;
 import org.repositoryminer.ast.AST;
-import org.repositoryminer.ast.MethodDeclaration;
 import org.repositoryminer.ast.AbstractTypeDeclaration;
+import org.repositoryminer.ast.MethodDeclaration;
+import org.repositoryminer.listener.IMetricCalculationListener;
 
 public class PARMetric extends MethodBasedMetricTemplate {
 
-	private List<Document> methodsDoc;
-	
 	@Override
-	public void calculate(AbstractTypeDeclaration type, List<MethodDeclaration> methods, AST ast, Document document) {
-		methodsDoc = new ArrayList<Document>();
+	public void calculate(AbstractTypeDeclaration type, List<MethodDeclaration> methods, AST ast, 
+			IMetricCalculationListener listener) {
+		Map<String, Integer> valuesPerMethod = new HashMap<String, Integer>();
+
 		int accumulated = 0;
-		
 		for(MethodDeclaration method : methods){
 			int par = calculate(method);
 			accumulated += par;
-			methodsDoc.add(new Document("method", method.getName()).append("value", new Integer(par)));
+			valuesPerMethod.put(method.getName(), new Integer(par));
 		}
 	
-		document.append("name", PAR).append("accumulated", new Integer(accumulated)).append("methods", methodsDoc);
+		listener.updateMethodBasedMetricValue(PAR, accumulated, valuesPerMethod);
 	}
 	
 	public int calculate(MethodDeclaration method){

--- a/src/main/java/org/repositoryminer/metric/SLOCMetric.java
+++ b/src/main/java/org/repositoryminer/metric/SLOCMetric.java
@@ -3,9 +3,9 @@ package org.repositoryminer.metric;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.bson.Document;
 import org.repositoryminer.ast.AST;
 import org.repositoryminer.ast.AbstractTypeDeclaration;
+import org.repositoryminer.listener.IMetricCalculationListener;
 
 public class SLOCMetric implements ICommitMetric{
 
@@ -16,10 +16,10 @@ public class SLOCMetric implements ICommitMetric{
 	}
 
 	@Override
-	public void calculate(AbstractTypeDeclaration type, AST ast, Document document) {
+	public void calculate(AbstractTypeDeclaration type, AST ast, IMetricCalculationListener listener) {
 		int sloc = calculate(ast.getSourceCode());
 		
-		document.append("name", SLOC).append("accumulated", new Integer(sloc));
+		listener.updateMetricValue(SLOC, sloc);
 	}
 	
 	public int calculate(String source){

--- a/src/main/java/org/repositoryminer/metric/TCCMetric.java
+++ b/src/main/java/org/repositoryminer/metric/TCCMetric.java
@@ -3,20 +3,21 @@ package org.repositoryminer.metric;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.bson.Document;
 import org.repositoryminer.ast.AST;
 import org.repositoryminer.ast.AbstractTypeDeclaration;
 import org.repositoryminer.ast.FieldDeclaration;
 import org.repositoryminer.ast.MethodDeclaration;
 import org.repositoryminer.ast.Statement;
 import org.repositoryminer.ast.Statement.NodeType;
+import org.repositoryminer.listener.IMetricCalculationListener;
 
 public class TCCMetric extends MethodBasedMetricTemplate {
 
 	@Override
-	public void calculate(AbstractTypeDeclaration type, List<MethodDeclaration> methods, AST ast, Document document) {
+	public void calculate(AbstractTypeDeclaration type, List<MethodDeclaration> methods, AST ast, 
+			IMetricCalculationListener listener) {
 		float tcc = calculate(type, methods);
-		document.append("name", TCC).append("accumulated", new Float(tcc));
+		listener.updateMetricValue(TCC, tcc);
 	}
 
 	public float calculate(AbstractTypeDeclaration type, List<MethodDeclaration> methods) {

--- a/src/main/java/org/repositoryminer/metric/WMCMetric.java
+++ b/src/main/java/org/repositoryminer/metric/WMCMetric.java
@@ -2,17 +2,18 @@ package org.repositoryminer.metric;
 
 import java.util.List;
 
-import org.bson.Document;
 import org.repositoryminer.ast.AST;
-import org.repositoryminer.ast.MethodDeclaration;
 import org.repositoryminer.ast.AbstractTypeDeclaration;
+import org.repositoryminer.ast.MethodDeclaration;
+import org.repositoryminer.listener.IMetricCalculationListener;
 
 public class WMCMetric extends MethodBasedMetricTemplate{
 
 	@Override
-	public void calculate(AbstractTypeDeclaration type, List<MethodDeclaration> methods, AST ast, Document document) {
+	public void calculate(AbstractTypeDeclaration type, List<MethodDeclaration> methods, AST ast, 
+			IMetricCalculationListener listener) {
 		int wmc = calculate(methods);
-		document.append("name", WMC).append("accumulated", new Integer(wmc));
+		listener.updateMetricValue(WMC, wmc);
 	}
 	
 	public int calculate(List<MethodDeclaration> methods){

--- a/src/main/java/org/repositoryminer/mining/MiningProcessor.java
+++ b/src/main/java/org/repositoryminer/mining/MiningProcessor.java
@@ -6,11 +6,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.bson.Document;
-import org.repositoryminer.persistence.handler.CommitDocumentHandler;
+import org.repositoryminer.listener.IMiningListener;
+import org.repositoryminer.listener.IProgressListener;
 import org.repositoryminer.persistence.handler.ReferenceDocumentHandler;
-import org.repositoryminer.persistence.handler.RepositoryDocumentHandler;
-import org.repositoryminer.persistence.handler.WorkingDirectoryDocumentHandler;
 import org.repositoryminer.persistence.model.CommitDB;
 import org.repositoryminer.persistence.model.ContributorDB;
 import org.repositoryminer.persistence.model.ReferenceDB;
@@ -22,56 +20,86 @@ import org.repositoryminer.utility.HashHandler;
 
 public class MiningProcessor {
 
-	private static void calculateMeasures(RepositoryMiner repoMiner, List<CommitDB> commits, List<ReferenceDB> scmRefs,
-			List<ReferenceDB> timeRefs, SCM scm, String repoId, String repoPath) throws UnsupportedEncodingException {
+	private RepositoryMiner repositoryMiner;
+	
+	private List<CommitDB> commits;
+	private List<ReferenceDB> scmRefs;
+	private List<ReferenceDB> timeRefs;
+	
+	private IProgressListener progressListener;
+	private IMiningListener miningListener;
+	
+	private SCM scm;
+	private String repoId, repoPath;
+
+	public MiningProcessor(RepositoryMiner repositoryMiner) {
+		this.repositoryMiner = repositoryMiner;
+	}
+	
+	public MiningProcessor setProgressListener(IProgressListener listener) {
+		progressListener = listener;
 		
-		boolean commitMetrics = (repoMiner.getCommitMetrics() != null && repoMiner.getCommitMetrics().size() > 0) ? true : false;
-		boolean commitTechnicalDebts = (repoMiner.getTechnicalDebts() != null
-				&& repoMiner.getTechnicalDebts().size() > 0) ? true : false;
-		boolean commitCodeSmells = (repoMiner.getCommitCodeSmells() != null
-				&& repoMiner.getCommitCodeSmells().size() > 0) ? true : false;
-		boolean tagCodeSmells = (repoMiner.getTagCodeSmells() != null && repoMiner.getTagCodeSmells().size() > 0) ? true
-				: false;
+		return this;
+	}
+	
+	public MiningProcessor setMiningListener(IMiningListener listener) {
+		miningListener = listener;
+		
+		return this;
+	}
+	
+	private void calculateAndDetect()
+					throws UnsupportedEncodingException {
+		boolean commitMetrics = (repositoryMiner.getCommitMetrics() != null
+				&& repositoryMiner.getCommitMetrics().size() > 0);
+		boolean commitTechnicalDebts = (repositoryMiner.getTechnicalDebts() != null
+				&& repositoryMiner.getTechnicalDebts().size() > 0);
+		boolean commitCodeSmells = (repositoryMiner.getCommitCodeSmells() != null
+				&& repositoryMiner.getCommitCodeSmells().size() > 0);
+		boolean tagCodeSmells = (repositoryMiner.getTagCodeSmells() != null
+				&& repositoryMiner.getTagCodeSmells().size() > 0);
 
 		if (!commitCodeSmells && !commitMetrics && !commitTechnicalDebts && !tagCodeSmells) {
+			//FIXME raise exception when no processing is required
 			return;
 		}
-		
+
 		List<ReferenceDB> tags = null;
 		if (tagCodeSmells) {
 			tags = new ArrayList<ReferenceDB>();
-			 for (ReferenceDB ref : scmRefs) {
-				 tags.add(ref);
-			 }
-			 for (ReferenceDB ref : timeRefs) {
-				 tags.add(ref);
-			 }
+			for (ReferenceDB ref : scmRefs) {
+				tags.add(ref);
+			}
+			for (ReferenceDB ref : timeRefs) {
+				tags.add(ref);
+			}
 		}
 
-		SourceAnalyzer sourceAnalyzer = new SourceAnalyzer(repoMiner, scm, repoId, repoPath);
+		SourceAnalyzer sourceAnalyzer = new SourceAnalyzer(repositoryMiner, miningListener, progressListener, scm,
+				repoId, repoPath);
 		sourceAnalyzer.setCommitCodeSmells(commitCodeSmells);
 		sourceAnalyzer.setCommitMetrics(commitMetrics);
 		sourceAnalyzer.setCommits(commits);
 		sourceAnalyzer.setCommitTechnicalDebts(commitTechnicalDebts);
 		sourceAnalyzer.setTagCodeSmells(tagCodeSmells);
 		sourceAnalyzer.setTags(tags);
-		
+
 		sourceAnalyzer.analyze();
 	}
 
-	public static void mine(RepositoryMiner repository) throws UnsupportedEncodingException {
-		SCM scm = SCMFactory.getSCM(repository.getScm());
-		scm.open(repository.getPath(), repository.getBinaryThreshold());
+	public void mine()
+					throws UnsupportedEncodingException {
+		scm = SCMFactory.getSCM(repositoryMiner.getScm());
+		scm.open(repositoryMiner.getPath(), repositoryMiner.getBinaryThreshold());
 
-		String absPath = scm.getAbsolutePath();
-		String id = HashHandler.SHA1(absPath);
+		repoPath = scm.getAbsolutePath();
+		repoId = HashHandler.SHA1(repoPath);
 
-		RepositoryDB r = new RepositoryDB(repository);
-		r.setId(id);
-		r.setPath(absPath);
+		RepositoryDB r = new RepositoryDB(repositoryMiner);
+		r.setId(repoId);
+		r.setPath(repoPath);
 
-		WorkingDirectoryDB wd = new WorkingDirectoryDB(id);
-		WorkingDirectoryDocumentHandler wdHandler = new WorkingDirectoryDocumentHandler();
+		WorkingDirectoryDB wd = new WorkingDirectoryDB(repoId);
 
 		ReferenceDocumentHandler refHandler = new ReferenceDocumentHandler();
 		List<ReferenceDB> refs = scm.getReferences();
@@ -81,34 +109,35 @@ public class MiningProcessor {
 		}
 
 		Set<ContributorDB> contributors = new HashSet<ContributorDB>();
-		CommitDocumentHandler commitHandler = new CommitDocumentHandler();
-
-		List<CommitDB> commits = scm.getCommits();
-		List<Document> docs = new ArrayList<Document>();
-
+		commits = scm.getCommits();
+		progressListener.initCommitsProcessingProgress(commits.size());
+		int idx = 0;
 		for (CommitDB c : commits) {
-			docs.add(c.toDocument());
+			progressListener.commitProgressChange(++idx, commits.size());
+
 			contributors.add(c.getCommitter());
 			wd.setId(c.getId());
 			wd.processDiff(c.getDiffs());
-			wdHandler.insert(wd.toDocument());
+
+			miningListener.updateCommit(c);
+			miningListener.updateWorkingDirectory(wd);
 		}
 
-		commitHandler.insertMany(docs);
-		
-		List<ReferenceDB> timeRefs = new ArrayList<ReferenceDB>();
-		if (repository.getTimeFrames() != null) {
-			ProcessTimeFrames procTimeFrames = new ProcessTimeFrames(absPath, id);
-			timeRefs = procTimeFrames.analyzeCommits(commits, repository.getTimeFrames());
+		timeRefs = new ArrayList<ReferenceDB>();
+		if (repositoryMiner.getTimeFrames() != null) {
+			progressListener.initTimeFramesProcessingProgress();
+
+			ProcessTimeFrames procTimeFrames = new ProcessTimeFrames(repoPath, repoId, progressListener);
+			timeRefs = procTimeFrames.analyzeCommits(commits, repositoryMiner.getTimeFrames());
 		}
 
-		calculateMeasures(repository, commits, refs, timeRefs, scm, id, absPath);
-		
-		RepositoryDocumentHandler repoHandler = new RepositoryDocumentHandler();
-		r.setContributors(new ArrayList<ContributorDB>(contributors));
-		repoHandler.insert(r.toDocument());
+		calculateAndDetect();
+
+		miningListener.updateRepository(r);
 
 		scm.close();
+
+		progressListener.endOfProcessingProgress();
 	}
 
 }

--- a/src/main/java/org/repositoryminer/mining/ProcessTimeFrames.java
+++ b/src/main/java/org/repositoryminer/mining/ProcessTimeFrames.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.TreeMap;
 
 import org.bson.Document;
+import org.repositoryminer.listener.IProgressListener;
 import org.repositoryminer.persistence.handler.ReferenceDocumentHandler;
 import org.repositoryminer.persistence.model.CommitDB;
 import org.repositoryminer.persistence.model.ReferenceDB;
@@ -21,11 +22,15 @@ public class ProcessTimeFrames {
 	private Map<String, ReferenceDB> refs;
 	private String repositoryPath;
 	private String repositoryId;
+	
+	private IProgressListener progressListener;
 
-	public ProcessTimeFrames(String repositoryPath, String repositoryId) {
+	public ProcessTimeFrames(String repositoryPath, String repositoryId, IProgressListener progressListener) {
 		this.refs = new TreeMap<String, ReferenceDB>();
 		this.repositoryPath = repositoryPath;
 		this.repositoryId = repositoryId;
+		
+		this.progressListener = progressListener;
 	}
 
 	public List<ReferenceDB> analyzeCommits(List<CommitDB> commits, List<TimeFrameType> timeFrames) {
@@ -51,7 +56,11 @@ public class ProcessTimeFrames {
 			}
 		}
 
+		progressListener.initCommitsProcessingProgress(commits.size());
+		int idx = 0;
 		for (CommitDB c : commits) {
+			progressListener.commitProgressChange(++idx, commits.size());
+			
 			Calendar calendar = Calendar.getInstance();
 			calendar.setTime(c.getCommitDate());
 

--- a/src/main/java/org/repositoryminer/mining/RepositoryMiner.java
+++ b/src/main/java/org/repositoryminer/mining/RepositoryMiner.java
@@ -6,6 +6,8 @@ import java.util.List;
 
 import org.repositoryminer.codesmell.commit.ICommitCodeSmell;
 import org.repositoryminer.codesmell.tag.ITagCodeSmell;
+import org.repositoryminer.listener.IMiningListener;
+import org.repositoryminer.listener.IProgressListener;
 import org.repositoryminer.metric.ICommitMetric;
 import org.repositoryminer.parser.Parser;
 import org.repositoryminer.scm.SCMType;
@@ -19,20 +21,16 @@ public class RepositoryMiner {
 	private SCMType scm;
 	private String charset = "UTF-8";
 	private int binaryThreshold = 2048;
+	
+	private IMiningListener miningListener;
+	private IProgressListener progressListener;
+	
 	private List<Parser> parsers;
 	private List<ICommitMetric> commitMetrics;
 	private List<ICommitCodeSmell> commitCodeSmells;
 	private List<ITechnicalDebt> technicalDebts;
 	private List<TimeFrameType> timeFrames;
 	private List<ITagCodeSmell> tagCodeSmells;
-
-	// TODO : To implement
-	// private boolean allowTextFiles;
-	// private List<String> allowedExtensions;
-
-	public void mine() throws UnsupportedEncodingException {
-		MiningProcessor.mine(this);
-	}
 
 	public RepositoryMiner() {
 	}
@@ -45,6 +43,28 @@ public class RepositoryMiner {
 		this.scm = scm;
 	}
 
+	// TODO : To implement
+	// private boolean allowTextFiles;
+	// private List<String> allowedExtensions;
+	public void mine() throws UnsupportedEncodingException {
+		MiningProcessor processor = new MiningProcessor(this);
+		processor.setProgressListener(progressListener).
+				setMiningListener(miningListener).
+				mine();
+	}
+	
+	public RepositoryMiner setMiningListener(IMiningListener listener) {
+		miningListener =listener;
+		
+		return this;
+	}
+	
+	public RepositoryMiner setProgressListener(IProgressListener listener) {
+		progressListener = listener;
+		
+		return this;
+	}
+	
 	public void setParsers(Parser... parsers) {
 		this.parsers = Arrays.asList(parsers);
 	}

--- a/src/main/java/org/repositoryminer/mining/SourceAnalyzer.java
+++ b/src/main/java/org/repositoryminer/mining/SourceAnalyzer.java
@@ -1,24 +1,17 @@
 package org.repositoryminer.mining;
 
 import java.io.UnsupportedEncodingException;
-import java.util.ArrayList;
 import java.util.List;
 
-import org.bson.Document;
 import org.repositoryminer.ast.AST;
 import org.repositoryminer.ast.AbstractTypeDeclaration;
-import org.repositoryminer.codesmell.commit.ICommitCodeSmell;
-import org.repositoryminer.codesmell.tag.ITagCodeSmell;
-import org.repositoryminer.metric.ICommitMetric;
+import org.repositoryminer.listener.IMiningListener;
+import org.repositoryminer.listener.IProgressListener;
 import org.repositoryminer.parser.Parser;
-import org.repositoryminer.persistence.handler.CommitAnalysisDocumentHandler;
-import org.repositoryminer.persistence.handler.TagAnalysisDocumentHandler;
 import org.repositoryminer.persistence.model.CommitDB;
 import org.repositoryminer.persistence.model.DiffDB;
 import org.repositoryminer.persistence.model.ReferenceDB;
 import org.repositoryminer.scm.SCM;
-import org.repositoryminer.technicaldebt.ITechnicalDebt;
-import org.repositoryminer.utility.HashHandler;
 
 public class SourceAnalyzer {
 
@@ -27,8 +20,9 @@ public class SourceAnalyzer {
 	private List<Parser> parsers;
 	private String repositoryId;
 	private String repositoryPath;
-	private CommitAnalysisDocumentHandler persistenceCommit;
-	private TagAnalysisDocumentHandler persistenceTag;
+
+	private IMiningListener miningListener;
+	private IProgressListener progressListener;
 
 	private boolean commitMetrics;
 	private boolean commitTechnicalDebts;
@@ -39,13 +33,16 @@ public class SourceAnalyzer {
 
 	private Parser parser = null;
 	
-	public SourceAnalyzer(RepositoryMiner repository, SCM scm, String repositoryId, String repositoryPath) {
+	public SourceAnalyzer(RepositoryMiner repository, 
+			IMiningListener miningListener, IProgressListener progressListener,
+			SCM scm, String repositoryId, String repositoryPath) {
 		this.scm = scm;
+		this.miningListener = miningListener;
+		this.progressListener = progressListener;
+		
 		this.repository = repository;
 		this.repositoryId = repositoryId;
 		this.repositoryPath = repositoryPath;
-		this.persistenceCommit = new CommitAnalysisDocumentHandler();
-		this.persistenceTag = new TagAnalysisDocumentHandler();
 		this.parsers = repository.getParsers();
 		
 		for (Parser parser : repository.getParsers()) {
@@ -81,7 +78,10 @@ public class SourceAnalyzer {
 	}
 
 	private void analyzeCommits() throws UnsupportedEncodingException {
+		int idx = 0;
 		for (CommitDB commit : commits) {
+			progressListener.commitProgressChange(++idx, commits.size());
+			
 			scm.checkout(commit.getId());
 
 			for (Parser parser : repository.getParsers()) {
@@ -123,91 +123,50 @@ public class SourceAnalyzer {
 	}
 
 	private void processTag(CommitDB commit, ReferenceDB tag) {
-		Document doc = new Document();
-		doc.append("tag", tag.getName());
-		doc.append("tag_type", tag.getType().toString());
-		doc.append("commit", commit.getId());
-		doc.append("commit_date", commit.getCommitDate());
-		doc.append("repository", repositoryId);
-		
-		processTagCodeSmells(doc);
-		persistenceTag.insert(doc);
+		miningListener.initTagProcessing(repositoryId, commit, tag);
+		processTagCodeSmells();
+		miningListener.endOfTagProcessing();
 	}
 	
-	private void processTagCodeSmells(Document tagDoc) {
+	private void processTagCodeSmells() {
 		if (tagCodeSmells) {
-			List<Document> codeSmellsDocs = new ArrayList<Document>();
-			for (ITagCodeSmell codeSmell : repository.getTagCodeSmells()) {
-				Document doc = new Document();
-				codeSmell.detect(parsers, repositoryPath, doc);
-				codeSmellsDocs.add(doc);
-			}
-			tagDoc.append("code_smells", codeSmellsDocs);
+			miningListener.updateAllTagCodeSmells(parsers, repositoryPath, repository.getTagCodeSmells());
 		}
 	}
 	
 	private void processCommit(CommitDB commit, String file, String hash, AST ast) {
-		Document doc = new Document();
-		doc.append("commit", commit.getId());
-		doc.append("commit_date", commit.getCommitDate());
-		doc.append("package", ast.getDocument().getPackageDeclaration());
-		doc.append("filename", file);
-		doc.append("repository", repositoryId);
-		doc.append("filehash", hash);
+		miningListener.initCommitProcessing(repositoryId, commit, ast, file, hash);
 
 		List<AbstractTypeDeclaration> types = ast.getDocument().getTypes();
-		List<Document> abstractTypeDocs = new ArrayList<Document>();
 		for (AbstractTypeDeclaration type : types) {
-			Document typeDoc = new Document();
-			String typeHash = file + "/" + type.getName();
-			typeDoc.append("name", type.getName()).append("declaration", type.getArchetype().toString()).append("hash",
-					HashHandler.SHA1(typeHash));
+			miningListener.initTypeProcessing(type, file);
 
-			List<Document> codeSmellsDocs = new ArrayList<Document>();
-			processCommitMetrics(ast, type, typeDoc);
-			processCommitCodeSmells(codeSmellsDocs, ast, type, typeDoc);
-			processTechnicalDebts(codeSmellsDocs, ast, type, typeDoc);
-			abstractTypeDocs.add(typeDoc);
+			processCommitMetrics(ast, type);
+			processCommitCodeSmells(ast, type);
+			processTechnicalDebts(ast, type);
+
+			miningListener.endOfTypeProcessing();
 		}
-
-		doc.append("abstract_types", abstractTypeDocs);
-		persistenceCommit.insert(doc);
+		
+		miningListener.endOfCommitProcessing();
 	}
 
-	private void processCommitMetrics(AST ast, AbstractTypeDeclaration type, Document typeDoc) {
-		if (commitMetrics) {
-			List<Document> metricsDoc = new ArrayList<Document>();
-			for (ICommitMetric metric : repository.getCommitMetrics()) {
-				Document mDoc = new Document();
-				metric.calculate(type, ast, mDoc);
-				metricsDoc.add(mDoc);
-			}
-			typeDoc.append("metrics", metricsDoc);
+	private void processCommitMetrics(AST ast, AbstractTypeDeclaration type) {
+		if (repository.getCommitMetrics() != null) {
+			miningListener.updateAllMetrics(type, ast, repository.getCommitMetrics());
 		}
 	}
 
-	private void processCommitCodeSmells(List<Document> codeSmellsDocs, AST ast, AbstractTypeDeclaration type, Document typeDoc) {
-		if (commitCodeSmells) {
-			for (ICommitCodeSmell codeSmell : repository.getCommitCodeSmells()) {
-				Document doc = new Document();
-				codeSmell.detect(type, ast, doc);
-				codeSmellsDocs.add(doc);
-			}
-			typeDoc.append("codesmells", codeSmellsDocs);
+	private void processCommitCodeSmells(AST ast, AbstractTypeDeclaration type) {
+		if (repository.getCommitCodeSmells() != null) {
+			miningListener.updateAllCommitCodeSmells(type, ast, repository.getCommitCodeSmells());
 		}
 	}
 
 	/** FIXME: Needs revision **/
-	private void processTechnicalDebts(List<Document> codeSmellsDoc, AST ast, AbstractTypeDeclaration type,
-			Document typeDoc) {
-		if (commitTechnicalDebts) {
-			List<Document> technicalDebtsDoc = new ArrayList<Document>();
-			for (ITechnicalDebt td : repository.getTechnicalDebts()) {
-				Document tdDoc = new Document();
-				td.detect(type, ast, codeSmellsDoc, tdDoc);
-				technicalDebtsDoc.add(tdDoc);
-			}
-			typeDoc.append("technicaldebts", technicalDebtsDoc);
+	private void processTechnicalDebts(AST ast, AbstractTypeDeclaration type) {
+		if (repository.getTechnicalDebts() != null) {
+			miningListener.updateAllTechnicalDebts(ast, type, repository.getTechnicalDebts());
 		}
 	}
 

--- a/src/main/java/org/repositoryminer/scm/GitSCM.java
+++ b/src/main/java/org/repositoryminer/scm/GitSCM.java
@@ -48,7 +48,6 @@ import org.slf4j.LoggerFactory;
  */
 public class GitSCM implements SCM {
 
-	private static final String RM_BRANCH = "RM-c1b31321c0";
 	private static final Logger LOGGER = LoggerFactory.getLogger(GitSCM.class);
 
 	private Repository repository;
@@ -219,7 +218,6 @@ public class GitSCM implements SCM {
 		if (lockFile.exists()) {
 			lockFile.delete();
 		}
-		makeCheckout("master", false);
 		makeCheckout(hash, true);
 	}
 
@@ -238,8 +236,6 @@ public class GitSCM implements SCM {
 			if (!git.status().call().isClean()) {
 				git.reset().setMode(ResetType.HARD).call();
 			}
-			makeCheckout("master", false);
-			git.branchDelete().setBranchNames(RM_BRANCH).setForce(true).call();
 		} catch (NoWorkTreeException | GitAPIException e) {
 			errorHandler(ErrorMessage.GIT_RESET_ERROR.toString(), e);
 		}
@@ -340,11 +336,7 @@ public class GitSCM implements SCM {
 
 	private void makeCheckout(String hash, boolean create) {
 		try{
-		if (create) {
-			git.checkout().setForce(true).setCreateBranch(true).setName(RM_BRANCH).setStartPoint(hash).call();
-		} else {
 			git.checkout().setForce(true).setName(hash).call();
-		}
 		} catch (GitAPIException e) {
 			errorHandler(ErrorMessage.GIT_CHECKOUT_ERROR.toString(), e);
 		}

--- a/src/main/java/org/repositoryminer/technicaldebt/CodeDebt.java
+++ b/src/main/java/org/repositoryminer/technicaldebt/CodeDebt.java
@@ -7,11 +7,12 @@ import org.repositoryminer.ast.AST;
 import org.repositoryminer.ast.AbstractTypeDeclaration;
 import org.repositoryminer.ast.AbstractTypeDeclaration.Archetype;
 import org.repositoryminer.codesmell.CodeSmellId;
+import org.repositoryminer.listener.ITechnicalDebtDetectionListener;
 
 public class CodeDebt implements ITechnicalDebt {
 	
 	@Override
-	public void detect(AbstractTypeDeclaration type, AST ast, List<Document> codeSmells, Document document) {
+	public void detect(AbstractTypeDeclaration type, AST ast, List<Document> codeSmells, ITechnicalDebtDetectionListener listener) {
 		if (type.getArchetype() == Archetype.CLASS_OR_INTERFACE) {
 			
 			boolean isCodeDebt = false;
@@ -23,9 +24,7 @@ public class CodeDebt implements ITechnicalDebt {
 				}
 				//TODO: Implements duplicated code detection and check for its existence when detect CodeDebt 				
 			}
-			document.append("name", TechnicalDebtId.CODE_DEBT)
-			.append("value", new Boolean(isCodeDebt))
-			.append("status", 0);
+			listener.updateDebtDetection(TechnicalDebtId.CODE_DEBT, new Boolean(isCodeDebt));
 		}
 	}
 

--- a/src/main/java/org/repositoryminer/technicaldebt/DesignDebt.java
+++ b/src/main/java/org/repositoryminer/technicaldebt/DesignDebt.java
@@ -7,12 +7,13 @@ import org.repositoryminer.ast.AST;
 import org.repositoryminer.ast.AbstractTypeDeclaration;
 import org.repositoryminer.ast.AbstractTypeDeclaration.Archetype;
 import org.repositoryminer.codesmell.CodeSmellId;
+import org.repositoryminer.listener.ITechnicalDebtDetectionListener;
 
 public class DesignDebt implements ITechnicalDebt {
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public void detect(AbstractTypeDeclaration type, AST ast, List<Document> antiPatterns, Document document) {
+	public void detect(AbstractTypeDeclaration type, AST ast, List<Document> antiPatterns, ITechnicalDebtDetectionListener listener) {
 		if (type.getArchetype() == Archetype.CLASS_OR_INTERFACE) {
 			boolean isDesignDebt = false;
 			for (Document antiPattern : antiPatterns) {
@@ -30,8 +31,12 @@ public class DesignDebt implements ITechnicalDebt {
 					}
 				}
 			}
-			document.append("name", TechnicalDebtId.DESIGN_DEBT).append("value", new Boolean(isDesignDebt)).append("status", 0);
+			listener.updateDebtDetection(TechnicalDebtId.DESIGN_DEBT, new Boolean(isDesignDebt));
 		}
+	}
+
+	public boolean detect(Document document) {
+		return false;
 	}
 
 }

--- a/src/main/java/org/repositoryminer/technicaldebt/ITechnicalDebt.java
+++ b/src/main/java/org/repositoryminer/technicaldebt/ITechnicalDebt.java
@@ -5,8 +5,9 @@ import java.util.List;
 import org.bson.Document;
 import org.repositoryminer.ast.AST;
 import org.repositoryminer.ast.AbstractTypeDeclaration;
+import org.repositoryminer.listener.ITechnicalDebtDetectionListener;
 
 public interface ITechnicalDebt {
 
-	public void detect(AbstractTypeDeclaration type, AST ast, List<Document> antiPatterns, Document document);
+	public void detect(AbstractTypeDeclaration type, AST ast, List<Document> codeSmells, ITechnicalDebtDetectionListener listener);
 }


### PR DESCRIPTION
Finished the addition of listeners to RM. Main listeners are: 

IProgressListener -> intented to observe the progress of mining processes. It can be used to provide user-friendly information about mined entities (commits, tags). Current set of covered steps is not exhaustive and one may expand it to meet further externalizations of information.

IMiningListener -> purpose is to detach source analysis (calculation/detection) from any specific use of mined information (as pushing it into mongodb). A default mining listener is provided,  org.repositoryminer.listener.impl.DefaultMiningListener (defaults the persistence to mongodb), but one may inject a different implementation to fit special needs.

Other listeners were added. They play auxiliary roles to the MiningListener by dividing the mining procedure in specifc concerns: metrics, smells, tags and others.

Whereas I am positive that IProgressListener should be accepted/merged, IMiningListener may lead to undesired complexity. On the other hand, as we concentrate persistence code in implementations of IMiningListener, it may facilitate the controlling of information being saved. Plus, we might be able to more easily define general storing strategies as DB routines won't be scattered out through source code.  