### PR TITLE
bugfix: removed parameter list from method name

### DIFF
--- a/repositoryminer-metrics/src/main/java/org/repositoryminer/metrics/parser/java/MethodVisitor.java
+++ b/repositoryminer-metrics/src/main/java/org/repositoryminer/metrics/parser/java/MethodVisitor.java
@@ -183,7 +183,11 @@ public class MethodVisitor extends ASTVisitor {
 	@Override
 	public boolean visit(MethodInvocation node) {
 		String methodName = node.getName().toString();
+		if (node.getExpression() == null)
+			return true;
 		ITypeBinding typeBinding = node.getExpression().resolveTypeBinding();
+		if (typeBinding == null)
+			return true;
 		String declaringClass = typeBinding.getQualifiedName();
 		StringBuilder parameters = new StringBuilder();
 

--- a/repositoryminer-metrics/src/main/java/org/repositoryminer/metrics/parser/java/TypeVisitor.java
+++ b/repositoryminer-metrics/src/main/java/org/repositoryminer/metrics/parser/java/TypeVisitor.java
@@ -190,6 +190,11 @@ public class TypeVisitor extends ASTVisitor {
 			return;
 		}
 
+		int paramListPosition = field.indexOf("(");
+		if (paramListPosition >= 0) {
+			field = field.substring(0, paramListPosition);
+		}
+
 		char c[] = field.toCharArray();
 		c[0] = Character.toLowerCase(c[0]);
 		String field2 = new String(c);


### PR DESCRIPTION
In method TypeVisitor.verifyAccessorMethod, the local variable field is using the method name with the types on the parameters list. So, most of the time an accessor method is not properly recognized.
Removing all after the opening parenthesis solves the problem.

Found this cause some metrics were always returning zeros.

Thanks